### PR TITLE
[RFR] Adding a unit test for checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+check-vmware/conf/cfme-qe-yamls
+check-vmware/doc_data.yaml
+check-vmware/__pycache__
+check-vmware/vmware_logconf/__pycache__
+*.log
+.check_venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+check-vmware/conf/.yaml_key
 check-vmware/conf/cfme-qe-yamls
 check-vmware/doc_data.yaml
 check-vmware/__pycache__

--- a/check-vmware/test_checks.py
+++ b/check-vmware/test_checks.py
@@ -1,0 +1,61 @@
+import pytest
+import random
+import yaml
+
+from pyVmomi import vim
+from vmware_checks import CHECKS
+from vmware_logconf import get_logger
+from wrapanapi.systems.virtualcenter import VMWareSystem
+
+
+@pytest.fixture(scope="session")
+def provider_data():
+    try:
+        with open("conf/cfme-qe-yamls/complete/cfme_data.yaml", "r") as stream:
+            cfme_data = yaml.safe_load(stream)
+    except IOError:
+        pytest.fail("CFME Data YAML file not found, no provider data available.")
+    else:
+        providers = cfme_data.get("management_systems")
+        vsphere_providers = {
+            key: providers[key] for key in list(providers.keys())
+            if providers[key].get("type") == "virtualcenter"
+        }
+        yield vsphere_providers.get(random.choice(list(vsphere_providers.keys())))
+
+@pytest.fixture(scope="session")
+def credentials(provider_data):
+    try:
+        with open("conf/cfme-qe-yamls/complete/credentials.yaml", "r") as stream:
+            creds = yaml.safe_load(stream)
+            yield creds.get(provider_data.get("credentials"))
+    except IOError:
+        pytest.fail("Credential YAML file not found or not decrypted!")
+
+
+@pytest.mark.parametrize("measurement", list(CHECKS.keys()))
+def test_checks(provider_data, credentials, measurement):
+    # get the necessary config
+    if measurement == "system_ping_vms":
+        # this test is very slow at present, and not used in shinken pack, so skip
+        pytest.skip("Measurement {} is unused, so skipping".format(measurement))
+    measure_func = CHECKS[measurement]
+    hostname = provider_data.get("hostname")
+    username, password = credentials.get("username"), credentials.get("password")
+    logger = get_logger(True)
+
+    # get the host if necessary
+    is_host_check = "host" in measure_func.__code__.co_varnames
+    host = None
+    if is_host_check:
+        # get the first host
+        host = provider_data.get("hosts")[0].get("name")
+
+    system = VMWareSystem(hostname, username, password)
+    if host:
+        host = system.get_obj(vim.HostSystem, host)
+
+    # now try run the check
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        measure_func(host or system, logger=logger)
+    assert pytest_wrapped_e.type == SystemExit

--- a/check-vmware/vmware_checks.py
+++ b/check-vmware/vmware_checks.py
@@ -320,6 +320,7 @@ def check_system_datastore_usage(system, warn=0.75, crit=0.9, **kwargs):
 
 def check_system_ping_vms(system, **kwargs):
     """ This checks the ping of all running VMs, no warning state for this check"""
+    # TODO: speed this check up
     logger = kwargs["logger"]
     vms = system.list_vms()
 

--- a/check-vmware/vmware_logconf/local_config.ini
+++ b/check-vmware/vmware_logconf/local_config.ini
@@ -13,15 +13,15 @@ handlers=fileHandler
 
 [handler_stream_handler]
 class=StreamHandler
-level=DEBUG
+level=INFO
 formatter=formatter
 args=(sys.stderr,)
 
 [handler_fileHandler]
-class=FileHandler
-level=DEBUG
+class=logging.handlers.TimedRotatingFileHandler
+level=INFO
 formatter=formatter
-args=("vmware-checks-" + time.strftime("%Y-%m-%d") + ".log", "a")
+args=("vmware-checks.log", "D")
 
 [formatter_formatter]
 format=[%(asctime)s %(filename)-17s %(levelname)-7s] %(message)s

--- a/check-vmware/vmware_logconf/logging_config.ini
+++ b/check-vmware/vmware_logconf/logging_config.ini
@@ -13,15 +13,15 @@ handlers=fileHandler
 
 [handler_stream_handler]
 class=StreamHandler
-level=DEBUG
+level=INFO
 formatter=formatter
 args=(sys.stderr,)
 
 [handler_fileHandler]
-class=FileHandler
-level=DEBUG
+class=logging.handlers.TimedRotatingFileHandler
+level=INFO
 formatter=formatter
-args=("/var/log/shinken/vmware-checks-" + time.strftime("%Y-%m-%d") + ".log", "a")
+args=("/var/log/shinken/vmware-checks.log", "D")
 
 [formatter_formatter]
 format=[%(asctime)s %(filename)-17s %(levelname)-7s] %(message)s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pyvcloud==19.1.2
 pyvmomi==6.7.1
+PyYAML==5.1.1
+pytest==5.0.1
 wrapanapi==3.0.43
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ pyvmomi==6.7.1
 PyYAML==5.1.1
 pytest==5.0.1
 wrapanapi==3.0.43
+yaycl
+yaycl_crypt
 


### PR DESCRIPTION
Adding a unit test for this check repo, it will run through all the checks in `vmware_checks` and make sure that they run properly. It requires you to have `cfme-qe-yamls` cloned in the conf directory. 

Also implementing the `logging.handlers.TimedRotatingFileHandler` so that logs will roll over automatically. This has the added benefit of making our checks python3 compatible. 